### PR TITLE
Merging issue/7/Support-duplicated-country-names into master

### DIFF
--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.Tests/Ibistic.Public.OpenAirportData.Tests.csproj
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.Tests/Ibistic.Public.OpenAirportData.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.Tests/Ibistic.Public.OpenAirportData.Tests.csproj
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.Tests/Ibistic.Public.OpenAirportData.Tests.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.Tests/OpenFlightsDataProviderTests.cs
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.Tests/OpenFlightsDataProviderTests.cs
@@ -6,7 +6,7 @@ using Ibistic.Public.OpenAirportData.MemoryDatabase;
 using Ibistic.Public.OpenAirportData.OpenFlightsData;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Ibistic.Public.OpenAirportData.Tests2
+namespace Ibistic.Public.OpenAirportData.Tests
 {
     [TestClass]
     public class OpenFlightsDataProviderTests
@@ -216,7 +216,7 @@ namespace Ibistic.Public.OpenAirportData.Tests2
         [TestMethod]
         public void TestListInvalidAirports()
         {
-            Dictionary<string, Country> countries = new Dictionary<string, Country>();
+            var countries = new Dictionary<string, Country>();
 
             using (var countryProvider = new OpenFlightsDataCountryProvider(Path.GetTempFileName()))
             {

--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.Tests/OpenFlightsDataProviderTests.cs
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.Tests/OpenFlightsDataProviderTests.cs
@@ -6,7 +6,7 @@ using Ibistic.Public.OpenAirportData.MemoryDatabase;
 using Ibistic.Public.OpenAirportData.OpenFlightsData;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Ibistic.Public.OpenAirportData.Tests
+namespace Ibistic.Public.OpenAirportData.Tests2
 {
     [TestClass]
     public class OpenFlightsDataProviderTests
@@ -216,13 +216,21 @@ namespace Ibistic.Public.OpenAirportData.Tests
         [TestMethod]
         public void TestListInvalidAirports()
         {
-            Dictionary<string, Country> countries;
+            Dictionary<string, Country> countries = new Dictionary<string, Country>();
 
             using (var countryProvider = new OpenFlightsDataCountryProvider(Path.GetTempFileName()))
             {
                 try
                 {
-                    countries = countryProvider.GetAllCountries().ToDictionary(x => x.Name);
+                    foreach (var country in countryProvider.GetAllCountries())
+                    {
+                        if (!string.IsNullOrEmpty(country.Name) && !countries.ContainsKey(country.Name))
+                        {
+                            countries.Add(country.Name, country);
+                        }
+
+                        //throw new InvalidDataException($"Invalid country with name {country.Name} received");
+                    }
                 }
                 finally
                 {
@@ -309,11 +317,30 @@ namespace Ibistic.Public.OpenAirportData.Tests
                     Assert.IsNotNull(malagaAirport);
                     Assert.IsTrue(malagaAirport.CountryAlpha2.Equals("ES", StringComparison.Ordinal));
 
+                    //OSLO
+                    airportFound = database.TryGetAirport("OSL", out Airport osloAirport);
+                    Assert.IsTrue(airportFound);
+                    Assert.IsNotNull(osloAirport);
+                    Assert.IsTrue(osloAirport.CountryAlpha2.Equals("NO", StringComparison.Ordinal));
+
+                    //COPENHAGEN
+                    airportFound = database.TryGetAirport("CPH", out Airport copenhagenAirport);
+                    Assert.IsTrue(airportFound);
+                    Assert.IsNotNull(copenhagenAirport);
+                    Assert.IsTrue(copenhagenAirport.CountryAlpha2.Equals("DK", StringComparison.Ordinal));
+
+                    //LONDON
+                    airportFound = database.TryGetAirport("LHR", out Airport londonAirport);
+                    Assert.IsTrue(airportFound);
+                    Assert.IsNotNull(londonAirport);
+                    Assert.IsTrue(londonAirport.CountryAlpha2.Equals("GB", StringComparison.Ordinal));
                     Assert.IsFalse(database.TryGetAirport("___", out _));
 
                 }
             }
         }
+
+
 
     }
 }

--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.sln
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.sln
@@ -1,14 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ibistic.Public.OpenAirportData", "Ibistic.Public.OpenAirportData\Ibistic.Public.OpenAirportData.csproj", "{7E1E0BC0-6375-434C-9034-B81F2C273833}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ibistic.Public.OpenAirportData", "Ibistic.Public.OpenAirportData\Ibistic.Public.OpenAirportData.csproj", "{7E1E0BC0-6375-434C-9034-B81F2C273833}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ibistic.Public.OpenAirportData.Tests", "Ibistic.Public.OpenAirportData.Tests\Ibistic.Public.OpenAirportData.Tests.csproj", "{6324D31D-59D3-489D-A0FF-59998DCBF32A}"
-	ProjectSection(ProjectDependencies) = postProject
-		{7E1E0BC0-6375-434C-9034-B81F2C273833} = {7E1E0BC0-6375-434C-9034-B81F2C273833}
-	EndProjectSection
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ibistic.Public.OpenAirportData.Tests", "Ibistic.Public.OpenAirportData.Tests\Ibistic.Public.OpenAirportData.Tests.csproj", "{B182F487-EA05-4CFD-9898-4DD1520BB8E0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,10 +17,10 @@ Global
 		{7E1E0BC0-6375-434C-9034-B81F2C273833}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E1E0BC0-6375-434C-9034-B81F2C273833}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E1E0BC0-6375-434C-9034-B81F2C273833}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6324D31D-59D3-489D-A0FF-59998DCBF32A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6324D31D-59D3-489D-A0FF-59998DCBF32A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6324D31D-59D3-489D-A0FF-59998DCBF32A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6324D31D-59D3-489D-A0FF-59998DCBF32A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B182F487-EA05-4CFD-9898-4DD1520BB8E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B182F487-EA05-4CFD-9898-4DD1520BB8E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B182F487-EA05-4CFD-9898-4DD1520BB8E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B182F487-EA05-4CFD-9898-4DD1520BB8E0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.csproj
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData.csproj
@@ -26,7 +26,7 @@ Please only use this component if you agree to and comply with the above license
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="7.1.1" />
+    <PackageReference Include="CsvHelper" Version="12.2.1" />
   </ItemGroup>
 
 </Project>

--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/OpenFlightsData/OpenFlightsCountryMapper.cs
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/OpenFlightsData/OpenFlightsCountryMapper.cs
@@ -8,7 +8,7 @@ namespace Ibistic.Public.OpenAirportData.OpenFlightsData
         {
             //Skip index 0 - Airport Id
             Map(m => m.Name).ConvertUsing(row => row.GetField<string>(0).StripNullString());
-            Map(m => m.Alpha2).ConvertUsing(row => row.GetField<string>(2).StripNullString());
+            Map(m => m.Alpha2).ConvertUsing(row => row.GetField<string>(1).StripNullString());
             Map(m => m.Alpha3).Ignore();
         }
 

--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/OpenFlightsData/OpenFlightsDataAirportProvider.cs
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/OpenFlightsData/OpenFlightsDataAirportProvider.cs
@@ -58,7 +58,7 @@ namespace Ibistic.Public.OpenAirportData.OpenFlightsData
 
         private IEnumerable<Airport> AddCountryInformation(IEnumerable<Airport> airports)
         {
-            Dictionary<string, Country> countriesByName = new Dictionary<string, Country>();
+            var countriesByName = new Dictionary<string, Country>();
 
             foreach (var country in _countryProvider.GetAllCountries())
             {

--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/OpenFlightsData/OpenFlightsDataAirportProvider.cs
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/OpenFlightsData/OpenFlightsDataAirportProvider.cs
@@ -18,7 +18,7 @@ namespace Ibistic.Public.OpenAirportData.OpenFlightsData
         public OpenFlightsDataAirportProvider(string cacheFileName, OpenFlightsDataCountryProvider countryProvider = null) : base(cacheFileName)
         {
             _countryProvider = countryProvider;
-            Source = new Uri("https://raw.githubusercontent.com/jpatokal/openflights/master/data/airports.dat");
+            Source = new Uri("https://raw.githubusercontent.com/jpatokal/openflights/30ec683370765ebb55e7ca24dba8decdd5dd25bc/data/airports.dat");
         }
 
         public int BadDataRowCount { get; private set; }
@@ -50,6 +50,7 @@ namespace Ibistic.Public.OpenAirportData.OpenFlightsData
             configuration.BadDataFound = context => BadDataRowCount++;
 
             _csvReader = new CsvReader(_textReader, configuration);
+
             var airports =  _csvReader.GetRecords<Airport>();
 
             return _countryProvider == null ? airports : AddCountryInformation(airports);
@@ -57,8 +58,17 @@ namespace Ibistic.Public.OpenAirportData.OpenFlightsData
 
         private IEnumerable<Airport> AddCountryInformation(IEnumerable<Airport> airports)
         {
-            Dictionary<string, Country> countriesByName = _countryProvider.GetAllCountries().Where(x => !String.IsNullOrEmpty(x.Name))
-                .ToDictionary(x => x.Name);
+            Dictionary<string, Country> countriesByName = new Dictionary<string, Country>();
+
+            foreach (var country in _countryProvider.GetAllCountries())
+            {
+                if (!string.IsNullOrEmpty(country.Name) && !countriesByName.ContainsKey(country.Name))
+                {
+                    countriesByName.Add(country.Name, country);
+                }
+                //this should throw exception for duplicate countries
+                
+            }
 
             foreach (var airport in airports)
             {

--- a/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/OpenFlightsData/OpenFlightsDataCountryProvider.cs
+++ b/Ibistic.Public.OpenAirportData/Ibistic.Public.OpenAirportData/OpenFlightsData/OpenFlightsDataCountryProvider.cs
@@ -15,7 +15,7 @@ namespace Ibistic.Public.OpenAirportData.OpenFlightsData
 
         public OpenFlightsDataCountryProvider(string cacheFileName) : base(cacheFileName)
         {
-            Source = new Uri("https://raw.githubusercontent.com/jpatokal/openflights/master/data/countries.dat");
+            Source = new Uri("https://raw.githubusercontent.com/jpatokal/openflights/30ec683370765ebb55e7ca24dba8decdd5dd25bc/data/countries.dat");
         }
 
         public int BadDataRowCount { get; private set; }


### PR DESCRIPTION
Implementing issue #7 in repository.

This includes: 

- Adding control to avoid crash when same country name is exported more than once.
- Changing airport and country provider url.
- Fixing some tests that were failing due to not handling duplicated country names properly.
- Adding more tests to guarantee airports and countries are imported properly.